### PR TITLE
fix(ci): open short-lived PR for protected main branch sync

### DIFF
--- a/.github/workflows/sync-upstream-images.yml
+++ b/.github/workflows/sync-upstream-images.yml
@@ -18,7 +18,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   sync-tags:
@@ -43,6 +43,7 @@ jobs:
       - name: Sync to PR branches and non-protected branches
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -137,5 +138,20 @@ jobs:
 
             git add .ci/upstream-images.env charts/rune/values.yaml || true
             git commit -m "chore(ci): sync ${IMAGE_NAME}:${IMAGE_TAG} from ${SOURCE_REPO}"
-            git push origin "HEAD:${branch}"
+
+            if [ "${branch}" = "main" ]; then
+              SYNC_BRANCH="ci/sync-main-$(git rev-parse --short HEAD)"
+              git checkout -b "${SYNC_BRANCH}"
+              git push origin "${SYNC_BRANCH}"
+              gh pr create \
+                --title "chore(ci): sync ${IMAGE_NAME}:${IMAGE_TAG} from ${SOURCE_REPO} to main" \
+                --body "Automated image tag sync. Auto-merges when CI passes." \
+                --base main \
+                --head "${SYNC_BRANCH}" \
+                --label "automated" 2>/dev/null || true
+              gh pr merge "${SYNC_BRANCH}" --auto --squash 2>/dev/null || true
+              git checkout "${branch}"
+            else
+              git push origin "HEAD:${branch}"
+            fi
           done <<< "${TARGET_BRANCHES}"


### PR DESCRIPTION
Closes #3

## What
When `sync-upstream-images` runs for the `main` branch (which has branch protection), instead of attempting a direct push (which fails silently with 403), it now:
1. Creates a short-lived branch `ci/sync-main-<sha>`
2. Pushes to that branch
3. Opens a PR targeting `main` with auto-merge enabled

All other branches (open PR branches, unprotected feature branches) continue to receive direct pushes as before.

## Why option 3
- Works with all branch protection configurations
- Gives full audit trail via PR history
- No changes needed to quality-gates.yml