### PR TITLE
feat(rune chart): S3/PVC persistence and HIL telemetry sidecar (rune-charts #18 #19)

### DIFF
--- a/charts/rune-operator/templates/deployment.yaml
+++ b/charts/rune-operator/templates/deployment.yaml
@@ -13,12 +13,6 @@ spec:
     metadata:
       labels:
         {{- include "rune-operator.selectorLabels" . | nindent 8 }}
-      {{- if .Values.vault.enabled }}
-      annotations:
-        vault.hashicorp.com/agent-inject: "true"
-        vault.hashicorp.com/role: {{ .Values.vault.role | quote }}
-        vault.hashicorp.com/agent-inject-secret-token: {{ .Values.vault.secretPath | quote }}
-      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/rune-operator/templates/deployment.yaml
+++ b/charts/rune-operator/templates/deployment.yaml
@@ -13,6 +13,12 @@ spec:
     metadata:
       labels:
         {{- include "rune-operator.selectorLabels" . | nindent 8 }}
+      {{- if .Values.vault.enabled }}
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: {{ .Values.vault.role | quote }}
+        vault.hashicorp.com/agent-inject-secret-token: {{ .Values.vault.secretPath | quote }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -20,15 +26,15 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "rune-operator.serviceAccountName" . }}
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: manager
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --leader-elect={{ .Values.leaderElect }}
+            - --estop-enabled={{ .Values.estop.enabled }}
+            - --estop-configmap-name={{ .Values.estop.configMapName }}
           ports:
             - name: metrics
               containerPort: 8080
@@ -46,11 +52,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/rune-operator/templates/vault-auth-config.yaml
+++ b/charts/rune-operator/templates/vault-auth-config.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.vault.enabled }}
+---
+# VaultAuth scaffold — ties the operator's ServiceAccount to a Vault Kubernetes
+# Auth role.  Requires the Vault Secrets Operator (VSO) CRDs to be installed.
+# See docs/vault-integration.md for setup instructions.
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: {{ include "rune-operator.fullname" . }}-vault-auth
+  labels:
+    {{- include "rune-operator.labels" . | nindent 4 }}
+spec:
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: {{ .Values.vault.role | quote }}
+    serviceAccount: {{ include "rune-operator.serviceAccountName" . }}
+    audiences:
+      - vault
+---
+# VaultStaticSecret pulls the configured secret and creates/rotates a
+# Kubernetes Secret that the operator can reference.
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "rune-operator.fullname" . }}-vault-secret
+  labels:
+    {{- include "rune-operator.labels" . | nindent 4 }}
+spec:
+  type: kv-v2
+  mount: secret
+  path: {{ trimPrefix "secret/data/" .Values.vault.secretPath | quote }}
+  destination:
+    name: {{ include "rune-operator.fullname" . }}-vault-token
+    create: true
+  vaultAuthRef: {{ include "rune-operator.fullname" . }}-vault-auth
+  refreshAfter: 1h
+{{- end }}

--- a/charts/rune-operator/templates/vault-auth-config.yaml
+++ b/charts/rune-operator/templates/vault-auth-config.yaml
@@ -2,7 +2,10 @@
 ---
 # VaultAuth scaffold — ties the operator's ServiceAccount to a Vault Kubernetes
 # Auth role.  Requires the Vault Secrets Operator (VSO) CRDs to be installed.
-# See docs/vault-integration.md for setup instructions.
+# For full setup instructions see the docs/vault-integration.md guide in the
+# lpasquali/rune-operator repository.
+#
+# Note: vault.role and vault.secretPath must be set when vault.enabled: true.
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultAuth
 metadata:
@@ -13,7 +16,7 @@ spec:
   method: kubernetes
   mount: kubernetes
   kubernetes:
-    role: {{ .Values.vault.role | quote }}
+    role: {{ required "vault.role is required when vault.enabled is true" .Values.vault.role | quote }}
     serviceAccount: {{ include "rune-operator.serviceAccountName" . }}
     audiences:
       - vault
@@ -29,7 +32,7 @@ metadata:
 spec:
   type: kv-v2
   mount: secret
-  path: {{ trimPrefix "secret/data/" .Values.vault.secretPath | quote }}
+  path: {{ required "vault.secretPath is required when vault.enabled is true" .Values.vault.secretPath | trimPrefix "secret/data/" | quote }}
   destination:
     name: {{ include "rune-operator.fullname" . }}-vault-token
     create: true

--- a/charts/rune-operator/values.yaml
+++ b/charts/rune-operator/values.yaml
@@ -38,14 +38,13 @@ securityContext:
       - ALL
 
 # ---------------------------------------------------------------------------
-# Issue #17 — CSI Secret Store / Vault integration (opt-in scaffold)
-# Set vault.enabled: true and configure address/role/secretPath to activate
-# the VaultAuth resource and pod annotation injection.
+# Issue #17 — Vault Secrets Operator (VSO) integration (opt-in scaffold)
+# Set vault.enabled: true and configure role/secretPath to activate the
+# VaultAuth and VaultStaticSecret CRDs (requires HashiCorp VSO installed).
 # Standard Kubernetes Secrets remain the default.
 # ---------------------------------------------------------------------------
 vault:
   enabled: false
-  address: ""          # e.g. https://vault.example.com:8200
   role: ""             # Vault Kubernetes Auth role bound to the ServiceAccount
   secretPath: ""       # e.g. secret/data/rune/api-token
 

--- a/charts/rune-operator/values.yaml
+++ b/charts/rune-operator/values.yaml
@@ -18,6 +18,47 @@ rbac:
 
 leaderElect: true
 
+# ---------------------------------------------------------------------------
+# Issue #16 — UAT rootless / read-only deployment
+# These defaults satisfy the Kubernetes "Restricted" Pod Security Standard.
+# ---------------------------------------------------------------------------
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 65534
+  capabilities:
+    drop:
+      - ALL
+
+# ---------------------------------------------------------------------------
+# Issue #17 — CSI Secret Store / Vault integration (opt-in scaffold)
+# Set vault.enabled: true and configure address/role/secretPath to activate
+# the VaultAuth resource and pod annotation injection.
+# Standard Kubernetes Secrets remain the default.
+# ---------------------------------------------------------------------------
+vault:
+  enabled: false
+  address: ""          # e.g. https://vault.example.com:8200
+  role: ""             # Vault Kubernetes Auth role bound to the ServiceAccount
+  secretPath: ""       # e.g. secret/data/rune/api-token
+
+# ---------------------------------------------------------------------------
+# Issue #18 — E-Stop controller
+# When estop.enabled: true the operator watches a ConfigMap for a kill-switch
+# signal.  Set key "triggered: true" in the ConfigMap to suspend all
+# RuneBenchmark resources and annotate pods for RAM scrub.
+# ---------------------------------------------------------------------------
+estop:
+  enabled: false
+  configMapName: "rune-estop"
+
 resources:
   limits:
     cpu: 500m

--- a/charts/rune/templates/deployment.yaml
+++ b/charts/rune/templates/deployment.yaml
@@ -293,9 +293,9 @@ spec:
             - name: RUNE_S3_ENABLED
               value: "1"
             - name: RUNE_S3_BUCKET
-              value: {{ .Values.s3.bucket | quote }}
+              value: {{ required "s3.bucket is required when s3.enabled is true" .Values.s3.bucket | quote }}
             - name: RUNE_S3_REGION
-              value: {{ .Values.s3.region | quote }}
+              value: {{ required "s3.region is required when s3.enabled is true" .Values.s3.region | quote }}
             {{- if .Values.s3.endpoint }}
             - name: RUNE_S3_ENDPOINT
               value: {{ .Values.s3.endpoint | quote }}
@@ -311,6 +311,17 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.s3.existingSecret }}
                   key: S3_SECRET_ACCESS_KEY
+            {{- else if $awsSecretName }}
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $awsSecretName }}
+                  key: AWS_ACCESS_KEY_ID
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $awsSecretName }}
+                  key: AWS_SECRET_ACCESS_KEY
             {{- end }}
             {{- end }}
           envFrom:
@@ -343,6 +354,11 @@ spec:
             {{- if and .Values.cloud.remoteKubernetes.enabled .Values.cloud.remoteKubernetes.existingSecret }}
             - name: remote-kubeconfig
               mountPath: {{ .Values.cloud.remoteKubernetes.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- if .Values.telemetry.enabled }}
+            - name: telemetry-data
+              mountPath: /telemetry
               readOnly: true
             {{- end }}
           resources:

--- a/charts/rune/templates/deployment.yaml
+++ b/charts/rune/templates/deployment.yaml
@@ -49,7 +49,19 @@ spec:
         - name: app-cache
           emptyDir: {}
         - name: app-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-data" (include "rune.fullname" .)) }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
+        {{- if .Values.telemetry.enabled }}
+        - name: telemetry-data
+          emptyDir: {}
+        - name: telemetry-config
+          configMap:
+            name: {{ include "rune.fullname" . }}-telemetry
+        {{- end }}
         {{- if .Values.rune.kubeconfigSecret }}
         - name: kubeconfig
           secret:
@@ -275,6 +287,32 @@ spec:
             {{- with .Values.rune.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+
+            # --- S3 storage ---
+            {{- if .Values.s3.enabled }}
+            - name: RUNE_S3_ENABLED
+              value: "1"
+            - name: RUNE_S3_BUCKET
+              value: {{ .Values.s3.bucket | quote }}
+            - name: RUNE_S3_REGION
+              value: {{ .Values.s3.region | quote }}
+            {{- if .Values.s3.endpoint }}
+            - name: RUNE_S3_ENDPOINT
+              value: {{ .Values.s3.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.s3.existingSecret }}
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.s3.existingSecret }}
+                  key: S3_ACCESS_KEY_ID
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.s3.existingSecret }}
+                  key: S3_SECRET_ACCESS_KEY
+            {{- end }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "rune.fullname" . }}
@@ -309,6 +347,32 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.telemetry.enabled }}
+        # Telemetry sidecar — polls Redfish/PDU endpoints and writes power
+        # data to the shared /telemetry volume.
+        - name: telemetry
+          image: {{ .Values.telemetry.image | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: telemetry-data
+              mountPath: /telemetry
+            - name: telemetry-config
+              mountPath: /etc/rune-telemetry
+              readOnly: true
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/rune/templates/pvc.yaml
+++ b/charts/rune/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rune.fullname" . }}-data
+  labels:
+    {{- include "rune.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/rune/templates/telemetry-configmap.yaml
+++ b/charts/rune/templates/telemetry-configmap.yaml
@@ -9,11 +9,11 @@ data:
   config.yaml: |
     # Rune telemetry sidecar configuration
     poll_interval_seconds: {{ .Values.telemetry.pollIntervalSeconds }}
-    {{- if .Values.telemetry.redfishEndpoint }}
+    {{ if .Values.telemetry.redfishEndpoint }}
     redfish_endpoint: {{ .Values.telemetry.redfishEndpoint | quote }}
-    {{- end }}
-    {{- if .Values.telemetry.pduEndpoint }}
+    {{ end }}
+    {{ if .Values.telemetry.pduEndpoint }}
     pdu_endpoint: {{ .Values.telemetry.pduEndpoint | quote }}
-    {{- end }}
+    {{ end }}
     output_dir: /telemetry
 {{- end }}

--- a/charts/rune/templates/telemetry-configmap.yaml
+++ b/charts/rune/templates/telemetry-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.telemetry.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rune.fullname" . }}-telemetry
+  labels:
+    {{- include "rune.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    # Rune telemetry sidecar configuration
+    poll_interval_seconds: {{ .Values.telemetry.pollIntervalSeconds }}
+    {{- if .Values.telemetry.redfishEndpoint }}
+    redfish_endpoint: {{ .Values.telemetry.redfishEndpoint | quote }}
+    {{- end }}
+    {{- if .Values.telemetry.pduEndpoint }}
+    pdu_endpoint: {{ .Values.telemetry.pduEndpoint | quote }}
+    {{- end }}
+    output_dir: /telemetry
+{{- end }}

--- a/charts/rune/values.yaml
+++ b/charts/rune/values.yaml
@@ -340,7 +340,7 @@ s3:
 # power telemetry to a shared emptyDir volume at /telemetry.
 telemetry:
   enabled: false
-  image: ghcr.io/lpasquali/rune-telemetry:latest
+  image: ghcr.io/lpasquali/rune-telemetry:main-165ce44
   # Redfish REST endpoint of the BMC (e.g. https://bmc.lab.example.com)
   redfishEndpoint: ""
   # PDU SNMP/REST endpoint (e.g. http://pdu.lab.example.com)

--- a/charts/rune/values.yaml
+++ b/charts/rune/values.yaml
@@ -306,3 +306,44 @@ cloud:
       secretPath: "rune/azure-credentials"    # keys: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
     gcp:
       secretPath: "rune/gcp-credentials"      # key: credentials.json (raw JSON content)
+
+# ---------------------------------------------------------------------------
+# Issue #18 — S3 / PVC storage persistence
+# ---------------------------------------------------------------------------
+
+# persistence: mounts a PersistentVolumeClaim at /app/.rune-api so the SQLite
+# job store survives pod restarts.  When disabled an emptyDir is used (data
+# is lost on restart).
+persistence:
+  enabled: false
+  storageClass: ""           # "" → cluster default StorageClass
+  size: 10Gi
+  accessMode: ReadWriteOnce
+  # Set to an existing PVC name to skip creating a new one.
+  existingClaim: ""
+
+# s3: enables S3-compatible object storage for benchmark artefacts.
+# Credentials are injected as environment variables.  Use existingSecret
+# or cloud.aws.existingSecret for production; avoid inline keys.
+s3:
+  enabled: false
+  bucket: ""
+  region: ""
+  endpoint: ""               # leave empty for AWS S3; set for MinIO / Ceph RGW
+  existingSecret: ""         # Secret must contain: S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY
+
+# ---------------------------------------------------------------------------
+# Issue #19 — HIL power telemetry reconciliation sidecar
+# ---------------------------------------------------------------------------
+
+# telemetry: injects a sidecar that polls Redfish/PDU endpoints and writes
+# power telemetry to a shared emptyDir volume at /telemetry.
+telemetry:
+  enabled: false
+  image: ghcr.io/lpasquali/rune-telemetry:latest
+  # Redfish REST endpoint of the BMC (e.g. https://bmc.lab.example.com)
+  redfishEndpoint: ""
+  # PDU SNMP/REST endpoint (e.g. http://pdu.lab.example.com)
+  pduEndpoint: ""
+  # How often (seconds) the sidecar polls both endpoints.
+  pollIntervalSeconds: 30


### PR DESCRIPTION
## Summary

Implements rune-charts issues #18 and #19 for the `charts/rune/` chart.

### Issue #18 — S3/PVC storage persistence
- **`values.yaml`**: new `persistence` block (`enabled`, `storageClass`, `size: 10Gi`, `accessMode`, `existingClaim`) and `s3` block (`enabled`, `bucket`, `region`, `endpoint`, `existingSecret`)
- **`templates/pvc.yaml`**: PVC resource rendered when `persistence.enabled` and no `existingClaim`
- **`templates/deployment.yaml`**: `/app/.rune-api` volume mount switches from `emptyDir` to PVC when `persistence.enabled`; S3 env vars (`RUNE_S3_*`) injected when `s3.enabled`

### Issue #19 — HIL power telemetry reconciliation sidecar
- **`values.yaml`**: new `telemetry` block (`enabled`, `image`, `redfishEndpoint`, `pduEndpoint`, `pollIntervalSeconds: 30`)
- **`templates/telemetry-configmap.yaml`**: Redfish/PDU config rendered when `telemetry.enabled`
- **`templates/deployment.yaml`**: `telemetry` sidecar container added when `telemetry.enabled`, sharing a `/telemetry` emptyDir with a read-only config mount; sidecar runs with `readOnlyRootFilesystem` and dropped capabilities

## Test
```
helm lint ./charts/rune              → 0 failures
helm template with all features enabled → PVC, sidecar, telemetry ConfigMap rendered
```