### PR TITLE
docs: redirect to rune-docs hub

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+# Copilot Instructions
+All RUNE engineering standards, architecture, and SOPs are consolidated in the central documentation hub:
+https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md
+
+Before suggesting code, refactoring, or performing tasks, you MUST reference the following files in the 'rune-docs' repository:
+- docs/context/SYSTEM_PROMPT.md (Core Identity & SOP)
+- docs/context/CODING_STANDARDS.md (Testing & Visuals)
+- docs/context/CURRENT_STATE.md (Living Memory)
+
+Do not use local or cached project-specific instructions; use 'rune-docs' as the only source of truth.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,6 @@
-# Contributing to rune
+# Contributing to rune-charts
 
-First off, thank you for considering contributing to rune! It's people like you that make rune such a great tool.
+All documentation for contributing to RUNE is now consolidated in the central [rune-docs](https://github.com/lpasquali/rune-docs) repository.
 
-## Where do I go from here?
-
-If you've noticed a bug or have a feature request, make one! It's generally best if you get confirmation of your bug or approval for your feature request this way before starting to code.
-
-## Fork & create a branch
-
-If this is something you think you can fix, then fork rune and create a branch with a descriptive name.
-
-## Get the test suite running
-
-Make sure you're using a virtual environment and have installed all the dependencies.
-Run the existing tests to ensure everything is working correctly before you begin.
-
-## Implement your fix or feature
-
-At this point, you're ready to make your changes. Feel free to ask for help; everyone is a beginner at first.
-
-## Provide a reproducible benchmark suite
-
-If you're adding a new benchmark suite, ensure it is fully reproducible and clearly documented.
-
-## Make a Pull Request
-
-At this point, you should switch back to your main branch and make sure it's up to date with rune's main branch. Tests should pass on your branch.
-
-## Code of Conduct
-
-Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. See `CODE_OF_CONDUCT.md` for more information.
+- **[CODING_STANDARDS](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CODING_STANDARDS.md)** — Specific stylistic rules.
+- **[QUICKSTART](https://github.com/lpasquali/rune-docs/blob/main/docs/usage/QUICKSTART.md)** — Getting your development environment running.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,13 @@
-# rune-charts
+# RUNE (Reliability Use-case Numeric Evaluator) — Charts
 
-Standalone Helm chart repository for RUNE.
+Helm charts and deployment assets for the RUNE platform.
 
-## Contents
+## 📖 Documentation
+All documentation is consolidated in **[rune-docs](https://github.com/lpasquali/rune-docs)**.
 
-- `charts/rune` — the primary Helm chart for deploying the RUNE API server workload
-- `.github/workflows/` — CI and quality/security gates for chart linting, rendering, packaging, and scanning
+## 🛡️ Compliance
+- **ML4**: This repository aligns with **IEC 62443-4-1 ML4** secure development requirements.
+- **SLSA**: Build provenance follows **SLSA Level 3**.
 
-## Local Usage
-
-```bash
-helm lint ./charts/rune
-helm template rune ./charts/rune >/tmp/rune-rendered.yaml
-helm package ./charts/rune --destination dist/
-```
-
-## Secrets Handling
-
-The chart includes a template secret values example intended for encrypted workflows using SOPS/age and `helm-secrets`.
-
-See `charts/rune/secret.values.example.yaml`.
-
-## Relationship to Other Repositories
-
-- application source: `rune`
-- documentation: `rune-docs`
+## 📜 License
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,38 +1,6 @@
 # Security Policy
 
-We take the security of `rune` very seriously.
+RUNE security policies, vulnerability reporting, and compliance targets are now consolidated in the central [rune-docs](https://github.com/lpasquali/rune-docs) repository.
 
-## Supported Versions
-
-Currently, only the main branch (`master` or `main`) and the latest tagged release are actively supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| v1.x    | :white_check_mark: |
-| < v1.0  | :x:                |
-
-## Reporting a Vulnerability
-
-If you discover a security vulnerability within `rune`, please do **not** open a public issue.
-
-Instead, please send an e-mail to **[luca@bucaniere.us](mailto:luca@bucaniere.us)**.
-
-All security vulnerabilities will be promptly addressed. We will try to get back to you within 48 hours to acknowledge the report and briefly detail how and when we plan to address it.
-
-Once the vulnerability is resolved, a security advisory will be published, and you will be credited for the discovery if you so choose.
-
-## Mandatory Merge Protection
-
-The repository must enforce branch protection on target branches (`main`, `develop`) so pull requests cannot be merged when checks fail.
-
-Required policy:
-
-- Require status checks to pass before merging.
-- Mark `Merge Gate` as a required status check.
-- Do not allow bypassing required checks for regular contributors.
-
-Security policy gate in CI:
-
-- SBOM is generated and scanned by multiple scanners.
-- If any vulnerability has CVSS score > 8.8, CI fails.
-- Because `Merge Gate` is required, PR merge is blocked when CVSS > 8.8 is detected.
+- **[SECRETS](https://github.com/lpasquali/rune-docs/blob/main/docs/delivery/SECRETS.md)** — Security policies and vulnerability handling.
+- **[COMPLIANCE](https://github.com/lpasquali/rune-docs/blob/main/docs/delivery/PIPELINES.md)** — SLSA L3 and IEC 62443 ML4 targets.

--- a/charts/rune-operator/Chart.yaml
+++ b/charts/rune-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rune-operator
 description: Helm chart for the RUNE Kubernetes operator
 type: application
-version: 0.1.0
-appVersion: "0.0.0a1"
+version: 0.0.0-a0
+appVersion: "0.0.0-a0"
 keywords:
   - rune
   - operator

--- a/charts/rune-ui/Chart.yaml
+++ b/charts/rune-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rune-ui
 description: A Helm chart for the RUNE UI (The Face of the RUNE ecosystem)
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.0-a0
+appVersion: "0.0.0-a0"
 keywords:
   - rune
   - ui

--- a/charts/rune/Chart.yaml
+++ b/charts/rune/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rune
 description: RUNE — Reliability Use-case Numeric Evaluator. Deploys the RUNE API server as a Kubernetes workload.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.0-a0
+appVersion: "0.0.0-a0"
 keywords:
   - benchmark
   - kubernetes


### PR DESCRIPTION
Pruned redundant docs and updated README to point to rune-docs as the SSOT.