### PR TITLE
[Legal] Add NOTICE file (Apache-2.0 Section 4(d))

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+RUNE Charts
+Copyright 2025-2026 The Rune Authors
+
+This product is licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
## Summary

- Adds NOTICE file with copyright attribution as required by Apache License 2.0 Section 4(d)
- No third-party dependencies to attribute (pure Helm charts)

Refs: lpasquali/rune#133

## DoD Level

Level 3 — Documentation/Legal-only change. No runtime code affected.

## Acceptance Criteria Evidence

- `ls NOTICE` confirms file exists at repo root
- `head -5 NOTICE` confirms canonical format with `Copyright 2025-2026 The Rune Authors`

```
$ ls NOTICE
/home/ubuntu/Devel/rune-charts/NOTICE

$ head -4 NOTICE
RUNE Charts
Copyright 2025-2026 The Rune Authors

This product is licensed under the Apache License, Version 2.0.
```

## Audit Checks

No triggers fired. This change adds a legal metadata file only — no dependencies added/bumped, no code changes, no CI workflow changes.

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)