### PR TITLE
ci: enable Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- ci: enable Dependabot for automated dependency updates

Closes #43

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation

## Acceptance Criteria Evidence

- CI passes with fix applied

## Audit Checks

cyber check:supply-chain — PASS (security/CI config change only)

## Breaking Changes

None.