### PR TITLE
fix: add license field to all Chart.yaml files

### DIFF
--- a/charts/rune-operator/Chart.yaml
+++ b/charts/rune-operator/Chart.yaml
@@ -11,5 +11,6 @@ keywords:
 home: https://github.com/lpasquali/rune-operator
 sources:
   - https://github.com/lpasquali/rune-operator
+license: Apache-2.0
 maintainers:
   - name: lpasquali

--- a/charts/rune-ui/Chart.yaml
+++ b/charts/rune-ui/Chart.yaml
@@ -10,6 +10,7 @@ keywords:
   - llm
   - benchmark
   - kubernetes
+license: Apache-2.0
 maintainers:
   - name: lpasquali
     email: luca.pasquali@example.com

--- a/charts/rune/Chart.yaml
+++ b/charts/rune/Chart.yaml
@@ -14,5 +14,6 @@ home: https://github.com/lpasquali/rune-charts
 sources:
   - https://github.com/lpasquali/rune-charts
   - https://github.com/lpasquali/rune
+license: Apache-2.0
 maintainers:
   - name: luca


### PR DESCRIPTION
## Summary
- Add `license: Apache-2.0` field to all three Helm charts (`rune`, `rune-operator`, `rune-ui`)
- Required for IEC 62443 ML4 legal compliance — license metadata must be present in all distributable artifacts

Closes #27

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation (metadata-only change)

## Acceptance Criteria Evidence

- [x] `rune/Chart.yaml` has `license: Apache-2.0`
- [x] `rune-operator/Chart.yaml` has `license: Apache-2.0`
- [x] `rune-ui/Chart.yaml` has `license: Apache-2.0`
- [x] `helm lint` passes for all 3 charts (0 failures)

## Audit Checks

No triggers fired — metadata field addition only, no dependencies/CI/API changes.

## Breaking Changes

None.

## Test plan

- [x] `helm lint charts/rune charts/rune-operator charts/rune-ui` — 3 charts linted, 0 failed
- [x] `grep "license:" charts/*/Chart.yaml` — all three show `Apache-2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)