### PR TITLE
fix: resolve Helm chart syntax and template issues for rune-audit

### DIFF
--- a/charts/rune-audit/templates/cronjob.yaml
+++ b/charts/rune-audit/templates/cronjob.yaml
@@ -6,54 +6,9 @@ metadata:
     {{- include "rune-audit.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.schedule | quote }}
-  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
-  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
-  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
-  jobTemplate:
-    spec:
-      template:
-        metadata:
-          {{- with .Values.podAnnotations }}
-          annotations:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          labels:
-            {{- include "rune-audit.labels" . | nindent 12 }}
-        spec:
-          {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          serviceAccountName: {{ include "rune-audit.serviceAccountName" . }}
-          securityContext:
-            {{- toYaml .Values.podSecurityContext | nindent 12 }}
-          containers:
-          - name: {{ .Chart.Name }}
-            securityContext:
-              {{- toYaml .Values.securityContext | nindent 12 }}
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
-            args: ["collect", "github-artifacts"]
-            env:
-              {{- toYaml .Values.env | nindent 14 }}
-            resources:
-              {{- toYaml .Values.resources | nindent 14 }}
-          restartPolicy: OnFailure
-          {{- with .Values.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.affinity }}
-          affinity:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-  concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  concurrencyPolicy: {{ .Values.concurrencyPolicy | default "Forbid" }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit | default 3 }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit | default 3 }}
   jobTemplate:
     metadata:
       labels:
@@ -62,6 +17,10 @@ spec:
       backoffLimit: 1
       template:
         metadata:
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           labels:
             {{- include "rune-audit.selectorLabels" . | nindent 12 }}
         spec:

--- a/charts/rune-audit/templates/serviceaccount.yaml
+++ b/charts/rune-audit/templates/serviceaccount.yaml
@@ -9,8 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-<<<<<<< HEAD
-=======
-automountServiceAccountToken: false
->>>>>>> 9948934 (feat: add Helm chart for rune-audit CronJob deployment)
+{{- if hasKey .Values.serviceAccount "automount" }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}
 {{- end }}

--- a/charts/rune-audit/values.yaml
+++ b/charts/rune-audit/values.yaml
@@ -1,70 +1,54 @@
+# Clean values.yaml for rune-audit
 image:
   repository: ghcr.io/lpasquali/rune-audit
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-schedule: "0 0 * * *" # Daily at midnight
+schedule: "0 6 * * 1" # Weekly Monday 6am UTC
 failedJobsHistoryLimit: 1
 successfulJobsHistoryLimit: 3
 concurrencyPolicy: Forbid
-
-# Command arguments for the audit (e.g. collect github-artifacts)
-args: ["collect", "github-artifacts"]
-
-env:
-  # GITHUB_TOKEN should be provided via a secret
-  - name: GITHUB_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: rune-audit-secrets
-        key: GITHUB_TOKEN
-
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
-
-podAnnotations: {}
-
-podSecurityContext:
-  runAsUser: 999
-  runAsGroup: 999
-  fsGroup: 999
-
-securityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop:
-    - ALL
-  privileged: false
-  readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 999
-  runAsGroup: 999
-
-resources:
-  limits:
-    cpu: 200m
-    memory: 256Mi
-  tag: latest
-  pullPolicy: IfNotPresent
-
-schedule: "0 6 * * 1"  # Weekly Monday 6am UTC
 
 config:
   owner: lpasquali
   repos: "rune,rune-operator,rune-ui,rune-charts,rune-docs,rune-audit,rune-airgapped"
 
+args: ["collect", "all"]
+
+githubToken:
+  create: false
+  secretName: ""
+  token: ""
+
 env: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automount: false
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 999
+  runAsGroup: 999
+  fsGroup: 999
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - ALL
 
 resources:
   limits:
@@ -77,30 +61,3 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
-serviceAccount:
-  create: true
-  name: ""
-  annotations: {}
-
-podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  fsGroup: 1000
-  seccompProfile:
-    type: RuntimeDefault
-
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: true
-  capabilities:
-    drop: [ALL]
-
-nameOverride: ""
-fullnameOverride: ""
-
-githubToken:
-  # If true, creates a Secret from the value below.
-  # If false, you must create the Secret yourself or use an ExternalSecret.
-  create: false
-  secretName: ""
-  token: ""


### PR DESCRIPTION
## Summary
Helm chart for rune-audit (CronJob deployment)

Fixes malformed YAML templates (CronJob, ServiceAccount, Values) that were blocking the deployment of `rune-audit` via Helm.

Closes #58

## DoD Level
- [x] **Level 1 — Full Validation**
- [ ] **Level 2 — Test Infrastructure**
- [ ] **Level 3 — Documentation**

## Acceptance Criteria Evidence
- [x] `cronjob.yaml` correctly templated and duplicate values removed.
- [x] `helm lint` passes without errors.

## Audit Checks
| Check | Result |
|---|---|
| `cyber check:api` | PASS |

## Breaking Changes
None.

## Test plan
- [x] `helm lint ./charts/rune-audit` passes.
