### PR TITLE
draft: SR-Q-023 audit log retention (values documentation)

### DIFF
--- a/charts/rune/values.yaml
+++ b/charts/rune/values.yaml
@@ -397,3 +397,13 @@ telemetry:
   pduEndpoint: ""
   # How often (seconds) the sidecar polls both endpoints.
   pollIntervalSeconds: 30
+
+# ---------------------------------------------------------------------------
+# SR-Q-023 — API audit log retention (operator / platform responsibility)
+# ---------------------------------------------------------------------------
+# RUNE emits structured JSON audit events on stderr. In Kubernetes, retention
+# is enforced by your log pipeline (Loki, ELK, cloud logging). Target >= 90 days.
+auditLogs:
+  retentionDays: 90
+  # Document for assessors: ship container logs to a sink whose retention policy
+  # meets or exceeds retentionDays (daily rotation / max chunk size in the SIEM).


### PR DESCRIPTION
## Summary

Sets Helm chart default `auditLogs.retentionDays` to **90** with inline comments mapping to SR-Q-023 (audit log retention).

## DoD Level

- [x] **Level 1** — Configuration default / documentation in values only

## Acceptance Criteria Evidence

- [x] `charts/rune/values.yaml`: `auditLogs.retentionDays: 90` and SR-Q-023 comment.

## Audit Checks

- **Helm / chart CI**: PASS — follow Actions on this PR (Helm lint and related jobs).

## Breaking Changes

None. Default retention change may affect new installs; overrides remain in consumer values.

### Issue tracking

Fixes lpasquali/rune-docs#224
Fixes lpasquali/rune-docs#207

