### PR TITLE
feat(charts): ship RuneBenchmark CRD (budget field)

### DIFF
--- a/charts/rune-operator/crds/bench.rune.ai_runebenchmarks.yaml
+++ b/charts/rune-operator/crds/bench.rune.ai_runebenchmarks.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
-  name: runebenchmarks.
+  name: runebenchmarks.bench.rune.ai
 spec:
-  group: ""
+  group: bench.rune.ai
   names:
     kind: RuneBenchmark
     listKind: RuneBenchmarkList
@@ -29,7 +29,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: ""
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/charts/rune-operator/crds/bench.rune.ai_runebenchmarks.yaml
+++ b/charts/rune-operator/crds/bench.rune.ai_runebenchmarks.yaml
@@ -1,0 +1,285 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: runebenchmarks.
+spec:
+  group: ""
+  names:
+    kind: RuneBenchmark
+    listKind: RuneBenchmarkList
+    plural: runebenchmarks
+    shortNames:
+    - rbm
+    singular: runebenchmark
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.workflow
+      name: Workflow
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.lastRun.status
+      name: LastRun
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: ""
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              agent:
+                description: Agent to run for agentic-agent workflow (e.g. holmes,
+                  k8sgpt)
+                type: string
+              apiBaseUrl:
+                type: string
+              apiTokenSecretRef:
+                type: string
+              attestationRequired:
+                description: When true, demands SLSA L3 signed provenance before execution
+                type: boolean
+              backendType:
+                default: ollama
+                description: BackendType is the LLM backend type (e.g., "ollama",
+                  "k8s-inference").
+                type: string
+              backendUrl:
+                type: string
+              backendWarmup:
+                description: Backend warmup options (agentic-agent, benchmark)
+                type: boolean
+              backendWarmupTimeoutSeconds:
+                format: int32
+                type: integer
+              backoffSeconds:
+                format: int32
+                type: integer
+              budget:
+                description: Budget optionally caps projected run cost using GET /v1/finops/simulate
+                  before the job is submitted.
+                properties:
+                  maxCostUSD:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Maximum allowed cost in USD for this execution (compared
+                      to cost_high_usd from GET /v1/finops/simulate when present, otherwise
+                      projected_cost_usd).
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([eE])([+-]?[0-9]+))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              costEstimation:
+                description: CostEstimation configures the pre-flight cost safety
+                  gate.
+                properties:
+                  aws:
+                    type: boolean
+                  azure:
+                    type: boolean
+                  gcp:
+                    type: boolean
+                  localEnergyRateKwh:
+                    type: number
+                  localHardware:
+                    description: Local hardware estimation
+                    type: boolean
+                  localHardwareLifespanYears:
+                    type: number
+                  localHardwarePurchasePrice:
+                    type: number
+                  localTdpWatts:
+                    type: number
+                  vastai:
+                    description: Cloud providers
+                    type: boolean
+                type: object
+              insecureTls:
+                type: boolean
+              kubeconfig:
+                description: Kubeconfig path forwarded to agentic-agent and benchmark
+                  jobs
+                type: string
+              maxDph:
+                type: number
+              minDph:
+                type: number
+              model:
+                type: string
+              pollIntervalSeconds:
+                description: PollIntervalSeconds is the interval between job status
+                  polls (default 5).
+                format: int32
+                maximum: 60
+                minimum: 2
+                type: integer
+              question:
+                type: string
+              reliability:
+                type: number
+              schedule:
+                type: string
+              suspend:
+                type: boolean
+              templateHash:
+                type: string
+              tenant:
+                type: string
+              timeoutSeconds:
+                format: int32
+                type: integer
+              vastai:
+                description: Vast.ai provisioning options (ollama-instance, benchmark)
+                type: boolean
+              vastaiStopInstance:
+                type: boolean
+              workflow:
+                type: string
+            required:
+            - apiBaseUrl
+            - workflow
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              consecutiveFailures:
+                format: int32
+                type: integer
+              history:
+                items:
+                  properties:
+                    completedAt:
+                      format: date-time
+                      type: string
+                    durationMillis:
+                      format: int64
+                      type: integer
+                    error:
+                      type: string
+                    result:
+                      description: Result contains the job output as a raw JSON string.
+                      type: string
+                    runId:
+                      type: string
+                    status:
+                      type: string
+                    submittedAt:
+                      format: date-time
+                      type: string
+                  type: object
+                type: array
+              lastRun:
+                properties:
+                  completedAt:
+                    format: date-time
+                    type: string
+                  durationMillis:
+                    format: int64
+                    type: integer
+                  error:
+                    type: string
+                  result:
+                    description: Result contains the job output as a raw JSON string.
+                    type: string
+                  runId:
+                    type: string
+                  status:
+                    type: string
+                  submittedAt:
+                    format: date-time
+                    type: string
+                type: object
+              lastScheduleTime:
+                format: date-time
+                type: string
+              lastSuccessfulTime:
+                format: date-time
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Summary

Adds **`charts/rune-operator/crds/bench.rune.ai_runebenchmarks.yaml`** so Helm installs the **RuneBenchmark** CRD (including optional **`spec.budget.maxCostUSD`**). CRD YAML synced from **`rune-operator`** (same content as `config/crd/bases/`).

Related: https://github.com/lpasquali/rune-operator/pull/94

## DoD Level

- [x] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)

## Level 1 Checklist

- [x] **Helm**: `helm lint ./charts/rune-operator` — *CI / reviewer (helm not available in agent env).*
- [x] **Breaking change audit** — Additive CRD file; corrects `metadata.name`, `spec.group`, `v1alpha1` version name.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| *No triggers fired* | — | YAML-only chart CRD; no supply-chain or dep changes beyond vendored CRD. |

## Acceptance Criteria Evidence

- [x] CRD matches operator repo `bench.rune.ai_runebenchmarks.yaml` for field parity.

## Test Plan Evidence

- [x] Chart structure: `crds/` is standard Helm 3 install path for cluster-scoped CRDs.

## Breaking Changes

None.

## Notes for Reviewer

Merge after or with **rune-operator** PR that introduces `spec.budget`.
