### PR TITLE
chore(ci): pin lpasquali/rune-ci reusable workflows to 9f939b2

### DIFF
--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   backfill:
-    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@main
+    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   sync:
-    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@main
+    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,10 +16,10 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
 
   helm:
-    uses: lpasquali/rune-ci/.github/workflows/helm-quality.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/helm-quality.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     with:
       chart-dirs: "charts/postgres charts/rune charts/rune-operator"
 
@@ -62,7 +62,7 @@ jobs:
   compliance:
     needs: [security, helm, integration]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     with:
       needs-json: ${{ toJson(needs) }}
       merge-gate-excludes: "helm,integration,security" # Force pass

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   release:
-    uses: lpasquali/rune-ci/.github/workflows/helm-release.yml@ac0bd4bc0253ee0261c2e2e63034aa2d7d903e5e # v0.1.0
+    uses: lpasquali/rune-ci/.github/workflows/helm-release.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # v0.1.0
     with:
       charts-dir: "charts"


### PR DESCRIPTION
## Summary

Pin every `lpasquali/rune-ci/.github/workflows/...` `workflow_call` to **`9f939b2c28317b6f55c1913c6a6485bd91e1bda5`** (current `rune-ci` `main`).

## Changes

- Replace prior SHAs: `40149ab…`, `b242495…`, `95f0b3…`, `ac0bd4…` (charts helm-release) where present.
- Replace `@main` branch pins on reusable workflow `uses:` with the same full SHA.

## Definition of Done

- [x] **Level 1**

## Acceptance Criteria Evidence

- All `uses: lpasquali/rune-ci/.github/workflows/…@` references in this repo use the new SHA; no `@main` for those paths.

## Audit Checks

No triggers fired.

## Breaking Changes

None.

Made with [Cursor](https://cursor.com)