### PR TITLE
docs(charts): make ingress block controller-agnostic per ADR 0008

### DIFF
--- a/charts/rune/VALUES.md
+++ b/charts/rune/VALUES.md
@@ -68,8 +68,8 @@ Override any value with `--set key=value` or a custom `values.yaml` file.
 | Key | Default | Description |
 |---|---|---|
 | `ingress.enabled` | `false` | Enable an Ingress resource |
-| `ingress.className` | `""` | IngressClass name |
-| `ingress.annotations` | `{}` | Ingress annotations (e.g. cert-manager issuer) |
+| `ingress.className` | `""` | IngressClass name; empty uses the cluster's default IngressClass (the one marked `ingressclass.kubernetes.io/is-default-class: "true"`). Chart is controller-agnostic (ADR 0008) |
+| `ingress.annotations` | `{}` | Controller-agnostic annotations (e.g. cert-manager issuer). Do not add nginx-ingress-specific annotations here |
 | `ingress.hosts` | see values.yaml | List of `{host, paths}` entries |
 | `ingress.tls` | `[]` | TLS configuration; add entries for HTTPS |
 

--- a/charts/rune/values-airgapped-prod.yaml
+++ b/charts/rune/values-airgapped-prod.yaml
@@ -167,9 +167,17 @@ service:
   annotations: {}
 
 ingress:
+  # The chart is ingress-agnostic (ADR 0008). Set enabled: true and
+  # configure the block below for production access via the cluster's
+  # chosen Ingress controller.
   enabled: false
-  # Set to true for production access via Ingress; configure carefully
-  # className: "nginx"
+  # Leave empty ("") to use the cluster's default IngressClass
+  # (the one marked ingressclass.kubernetes.io/is-default-class: "true").
+  # Otherwise set to your platform's class name.
+  # Examples: "traefik", "envoy", "cilium", "istio", "nginx".
+  # className: ""
+  # Controller-agnostic annotations only. Do NOT add
+  # nginx-ingress-specific annotations here.
   # annotations:
   #   cert-manager.io/cluster-issuer: letsencrypt-prod
   # hosts:

--- a/charts/rune/values.yaml
+++ b/charts/rune/values.yaml
@@ -69,10 +69,19 @@ service:
 # Ingress
 # ---------------------------------------------------------------------------
 ingress:
+  # The chart is ingress-agnostic. It renders a generic
+  # networking.k8s.io/v1 Ingress and delegates the controller choice
+  # to the cluster's platform. See ADR 0008 in rune-docs.
   enabled: false
+  # Leave empty ("") to use the cluster's default IngressClass
+  # (the one marked ingressclass.kubernetes.io/is-default-class: "true").
+  # Otherwise set to your platform's class name.
+  # Examples: "traefik", "envoy", "cilium", "istio", "nginx".
   className: ""
+  # Controller-agnostic annotations only. Do NOT add
+  # nginx-ingress-specific annotations here; prefer equivalent
+  # Ingress / Gateway API fields or your controller's own CRDs.
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # cert-manager.io/cluster-issuer: letsencrypt-prod
   hosts:
     - host: rune.example.com


### PR DESCRIPTION
## Summary

Comment-only cleanup in `charts/rune/values.yaml`, `charts/rune/values-airgapped-prod.yaml`, and `charts/rune/VALUES.md` to make the ingress block controller-agnostic per ADR 0008 (rune-docs#296). No template / manifest changes; `helm template` render is identical.

Closes #98
Epic: #295 (rune-docs)

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] `mkdocs build --strict` — not applicable (rune-charts has no mkdocs site; VALUES.md is a plain README consumed by humans and by chart registry tooling).
- [x] Markdown linting on `VALUES.md` — handled by the repo's `helm-quality` CI gate on PR.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| n/a | No triggers fired | Chart values comments only; no Helm template, Dockerfile, dep, or workflow change. `helm lint` / `helm template` output unchanged. |

## Acceptance Criteria Evidence

- [x] Zero `nginx.ingress.kubernetes.io/*` occurrences in `charts/rune/**`.
  - `grep -rn 'nginx\.ingress\.kubernetes\.io' charts/` → empty.
- [x] `ingress.className` semantics documented inline in both values files (empty = cluster's default IngressClass).
- [x] Examples list nginx as one of many valid class names, alongside traefik / envoy / cilium / istio — no single controller privileged.
- [x] Warning in the annotations comment not to add nginx-ingress-specific annotations (phrased without the literal annotation prefix so rune-ci#41 lint doesn't flag the warning itself).
- [x] `charts/rune/VALUES.md` rows for `ingress.className` and `ingress.annotations` updated to match.
- [x] `helm lint charts/rune` — will run in the repo's `helm-quality` CI job on this PR.
- [x] `helm template` render unchanged — no templates modified; values comments do not affect rendering.

## Test Plan Evidence

- `grep -rn 'nginx\.ingress\.kubernetes\.io' charts/` → 0 matches.
- `grep -n 'nginx' charts/rune/values*.yaml` → 4 matches, all in neutral context (example class list; "do not add nginx-ingress-specific annotations" warning).
- CI `helm-quality` will run `helm lint` and `helm template` as the canonical verification.

## Breaking Changes

None. Default `ingress.className: ""` continues to mean "use cluster default IngressClass"; users who had explicitly set `className: "nginx"` are unaffected.

## Notes for Reviewer

- The Gateway API template (rune-charts#99) is a separate non-blocking follow-up; this PR does not add it.
- The pre-existing `templates/ingress.yaml` was already generic networking.k8s.io/v1 and required no change — verified during epic inventory (rune-docs#295).

Made with [Cursor](https://cursor.com)