### PR TITLE
feat(charts): optional Gateway API HTTPRoute behind gatewayApi.enabled (ADR 0008)

### DIFF
--- a/charts/rune/VALUES.md
+++ b/charts/rune/VALUES.md
@@ -73,6 +73,20 @@ Override any value with `--set key=value` or a custom `values.yaml` file.
 | `ingress.hosts` | see values.yaml | List of `{host, paths}` entries |
 | `ingress.tls` | `[]` | TLS configuration; add entries for HTTPS |
 
+## Gateway API (optional)
+
+The chart ships an opt-in `HTTPRoute` for clusters that prefer Gateway API over Ingress. Independent of the `ingress:` block; either, both, or neither may be enabled. Requires `gateway.networking.k8s.io/v1` CRDs on the cluster; when `gatewayApi.enabled` is `false` the chart does not reference those CRDs at all (safe on clusters without them).
+
+| Key | Default | Description |
+|---|---|---|
+| `gatewayApi.enabled` | `false` | Render an `HTTPRoute` and attach it to an existing Gateway |
+| `gatewayApi.parentRef.name` | `""` | **Required** when enabled. Name of the `Gateway` to attach to (not created by this chart) |
+| `gatewayApi.parentRef.namespace` | `""` | Namespace of the Gateway (empty → same namespace as this release) |
+| `gatewayApi.parentRef.sectionName` | `""` | Optional listener name on the Gateway |
+| `gatewayApi.parentRef.port` | `null` | Optional listener port on the Gateway |
+| `gatewayApi.hostnames` | `[]` | Hostnames served by this route (must be allowed by the Gateway) |
+| `gatewayApi.rules` | `[]` | HTTPRoute rules; empty → one default rule sending all paths to this release's Service on `service.port` |
+
 ---
 
 ## Resources & scheduling

--- a/charts/rune/templates/httproute.yaml
+++ b/charts/rune/templates/httproute.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.gatewayApi.enabled -}}
+{{- $fullName := include "rune.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if not .Values.gatewayApi.parentRef.name -}}
+{{- fail "gatewayApi.enabled=true requires gatewayApi.parentRef.name to reference an existing Gateway" -}}
+{{- end -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "rune.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.gatewayApi.parentRef.name | quote }}
+      {{- with .Values.gatewayApi.parentRef.namespace }}
+      namespace: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.gatewayApi.parentRef.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.gatewayApi.parentRef.port }}
+      port: {{ . }}
+      {{- end }}
+  {{- with .Values.gatewayApi.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.gatewayApi.rules }}
+    {{- toYaml .Values.gatewayApi.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/rune/values.yaml
+++ b/charts/rune/values.yaml
@@ -95,6 +95,44 @@ ingress:
   #      - rune.example.com
 
 # ---------------------------------------------------------------------------
+# Gateway API (optional)
+# ---------------------------------------------------------------------------
+# Opt-in HTTPRoute for clusters that prefer Gateway API over Ingress
+# (Cilium Gateway, Istio Gateway, Envoy Gateway, ...). Independent of
+# the `ingress:` block above — you may enable either, both, or neither.
+# Requires the Gateway API CRDs (gateway.networking.k8s.io/v1) installed
+# on the cluster; when `enabled: false` this chart does not reference
+# those CRDs, so it remains installable on clusters without them.
+gatewayApi:
+  enabled: false
+  # Reference to the Gateway this HTTPRoute attaches to. The Gateway is
+  # NOT managed by this chart — the cluster operator provisions it.
+  parentRef:
+    # name is required when enabled.
+    name: ""
+    # namespace of the Gateway (optional; defaults to the route's namespace).
+    namespace: ""
+    # sectionName is optional (Gateway listener name); leave empty to
+    # attach to all matching listeners.
+    sectionName: ""
+    # port is optional (restrict to a specific listener port).
+    port: null
+  # Hostnames served by this HTTPRoute (must be allowed by the Gateway).
+  hostnames: []
+    # - rune.example.com
+  # HTTPRoute rules. If empty, a single default rule routes all paths to
+  # the chart's own Service on .Values.service.port.
+  rules: []
+    # - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
+    #   backendRefs:
+    #     - name: rune
+    #       port: 8080
+    #       weight: 1
+
+# ---------------------------------------------------------------------------
 # Resources
 # ---------------------------------------------------------------------------
 resources: {}


### PR DESCRIPTION
## Summary

Opt-in Gateway API path for the `rune` chart. Adds a `gatewayApi` values block (default `enabled: false`) and a new `templates/httproute.yaml`. Independent of the existing `ingress:` block — either, both, or neither may be enabled. When `enabled: false` the chart does not reference the `gateway.networking.k8s.io/v1` CRDs, so it stays installable on clusters without them.

Closes #99
Epic: #295 (rune-docs)

## DoD Level

- [x] **Level 1 — Full Validation**
- [ ] **Level 2 — Test Infrastructure**
- [ ] **Level 3 — Documentation**

## Level 1 Checklist

- [x] Tested in **docker-compose mode** — n/a for a chart template; helm is the canonical build.
- [x] Tested in **kind (Kubernetes) mode** — `helm template` render verified across four scenarios (see Test Plan Evidence). CI `integration / Deployment Test (K8s 1.34.3 / 1.35.0)` exercises install/upgrade with default values (`gatewayApi.enabled=false`), which is the only guaranteed-safe configuration on clusters without Gateway API CRDs.
- [x] Tested in **standalone CLI mode** — n/a.
- [x] **Breaking change audit** — default `gatewayApi.enabled=false` means no rendered change for any existing installation. Chart surface grows by one optional block; no existing fields changed.
- [x] **Dependency CVE audit** — no deps changed; template-only addition.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `cyber check:api` | PASS | New resource kind is `gateway.networking.k8s.io/v1 HTTPRoute` (stable GA since K8s 1.30 Gateway API v1.0). Gated behind `gatewayApi.enabled: false` default. |

## Acceptance Criteria Evidence

- [x] `helm template` with `gatewayApi.enabled=true` renders a valid `HTTPRoute`:
  ```yaml
  apiVersion: gateway.networking.k8s.io/v1
  kind: HTTPRoute
  metadata:
    name: test-rune
  spec:
    parentRefs:
      - name: "my-gateway"
    hostnames:
      - "rune.example.com"
    rules:
      - matches:
          - path:
              type: PathPrefix
              value: /
        backendRefs:
          - name: test-rune
            port: 8080
  ```
- [x] `helm lint charts/rune` passes (only INFO about icon, pre-existing).
- [x] CRD compatibility — `helm template` with **default values** (`gatewayApi.enabled=false`) emits **zero** `HTTPRoute` resources; the chart does not require Gateway API CRDs to install.
- [x] README section added — `charts/rune/VALUES.md` now documents all six new keys.

## Test Plan Evidence

Using helm v3.20.2 (installed locally):

```
$ helm lint charts/rune
1 chart(s) linted, 0 chart(s) failed

$ helm template test charts/rune 2>&1 | grep -c "kind: HTTPRoute"
0

$ helm template test charts/rune --set gatewayApi.enabled=true 2>&1 | tail -3
Error: execution error at (rune/templates/httproute.yaml:5:4):
  gatewayApi.enabled=true requires gatewayApi.parentRef.name to reference an existing Gateway

$ helm template test charts/rune \
    --set gatewayApi.enabled=true \
    --set gatewayApi.parentRef.name=my-gateway \
    --set gatewayApi.hostnames[0]=rune.example.com \
  | grep -A12 "kind: HTTPRoute"
(renders valid HTTPRoute pointing at test-rune:8080 by default)

$ helm template test charts/rune \
    --set ingress.enabled=true \
    --set gatewayApi.enabled=true \
    --set gatewayApi.parentRef.name=gw \
    --set gatewayApi.hostnames[0]=a.example.com \
  | grep -cE "^kind: (Ingress|HTTPRoute)$"
2

$ helm template test charts/rune \
    --set gatewayApi.enabled=true \
    --set gatewayApi.parentRef.name=gw \
    --set gatewayApi.hostnames[0]=a.example.com \
    --set-json 'gatewayApi.rules=[{"matches":[...],"backendRefs":[{"name":"api-svc","port":8080}]}]'
(custom rule renders; backendRef is api-svc:8080, not the default Service)
```

## Breaking Changes

None. Default `gatewayApi.enabled=false` preserves existing behavior. Chart installs unchanged on clusters without the Gateway API CRDs.

## Notes for Reviewer

- The chart **does not create the Gateway resource** — that's the cluster operator's concern. Users provide `gatewayApi.parentRef.name` referencing an existing Gateway.
- `helm {{ fail }}` is used to surface the "parentRef.name is required when enabled" error at template time, so `helm install`/`upgrade` fails loud instead of shipping a malformed `HTTPRoute`.
- Chart version in `Chart.yaml` is **not** bumped in this PR, matching the convention of the previous rune-charts#98 comment-only refactor. If a bump is desired for the release pipeline, it can ride a subsequent PR.

Made with [Cursor](https://cursor.com)