### PR TITLE
docs(readme): hyperlink Helm, IEC 62443-4-1, and SLSA to official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # RUNE (Reliability Use-case Numeric Evaluator) — Charts
 
-Helm charts and deployment assets for the RUNE platform.
+[Helm](https://helm.sh/docs/) charts and deployment assets for the RUNE platform.
 
 ## 📖 Documentation
 All documentation is consolidated in the **[RUNE Documentation Site](https://lpasquali.github.io/rune-docs/)**.
 
 ## 🛡️ Compliance
-- **ML4**: This repository is designed to align with **IEC 62443-4-1 ML4** secure development requirements in preparation for future certification.
-- **SLSA**: Build provenance is designed to follow **SLSA Level 3** guidelines.
+- **ML4**: This repository is designed to align with **[IEC 62443-4-1](https://webstore.iec.ch/publication/33615) ML4** secure development requirements in preparation for future certification. ([ISA overview](https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards))
+- **SLSA**: Build provenance is designed to follow **[SLSA Level 3](https://slsa.dev/spec/v1.0/)** guidelines.
 
 ## 📜 License
 Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Hyperlinks **Helm**, **IEC 62443-4-1**, and **SLSA Level 3** in the README to their official docs/spec URLs. URLs from the rune-docs External Links Catalog.

Closes #104
Epic: —

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] Manual diff review
- [x] Links resolve (HTTP 200/301): helm.sh/docs, webstore.iec.ch, isa.org, slsa.dev

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] Helm → helm.sh/docs — evidence: `README.md` line 3 diff
- [x] IEC 62443-4-1 → IEC Webstore + ISA overview — evidence: `README.md` diff
- [x] SLSA Level 3 → slsa.dev/spec/v1.0 — evidence: `README.md` diff

## Test Plan Evidence

- [x] Diff review: 1 file, 3 lines modified
- [x] All 4 target URLs return 2xx/3xx

## Breaking Changes

None.

## Notes for Reviewer

Cross-repo sweep companion to rune-docs PR #307, rune#268, rune-operator#116, rune-ui#140.