### PR TITLE
Consolidate Dependabot updates and update rune-ci pins

### DIFF
--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   backfill:
-    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
+    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   sync:
-    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
+    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,10 +16,10 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
 
   helm:
-    uses: lpasquali/rune-ci/.github/workflows/helm-quality.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/helm-quality.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       chart-dirs: "charts/postgres charts/rune charts/rune-operator"
 
@@ -37,7 +37,7 @@ jobs:
       - name: Build rune chart dependency
         run: helm dependency build charts/rune
       - name: Start kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           node_image: kindest/node:v${{ matrix.k8s-version }}
           wait: 120s
@@ -60,12 +60,12 @@ jobs:
           done
 
   guard:
-    uses: lpasquali/rune-ci/.github/workflows/nginx-ingress-guard.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/nginx-ingress-guard.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
 
   compliance:
     needs: [security, helm, integration, guard]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       needs-json: ${{ toJson(needs) }}
       merge-gate-excludes: "helm,integration,security,guard" # Force pass

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   release:
-    uses: lpasquali/rune-ci/.github/workflows/helm-release.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # v0.1.0
+    uses: lpasquali/rune-ci/.github/workflows/helm-release.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       charts-dir: "charts"

--- a/.github/workflows/sync-upstream-images.yml
+++ b/.github/workflows/sync-upstream-images.yml
@@ -19,7 +19,7 @@ jobs:
       IMAGE_TAG: ${{ github.event.client_payload.image_tag || inputs.image_tag }}
       SOURCE_REPO: ${{ github.event.client_payload.source_repo || inputs.source_repo || github.repository }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Consolidated pending Dependabot GitHub Action updates and updated `rune-ci` reusable workflow pins to the latest baseline.

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Verified workflow YAML syntax
- [x] **CI impact audit**: No changes to build/test logic, only version bumps.
- [x] Verified pinned SHAs match upstream releases.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `supply-chain check:actions` | PASS | All actions updated to latest pinned SHAs. |

## Acceptance Criteria Evidence

- [x] All GitHub Actions bumped to versions requested by Dependabot.
- [x] All `rune-ci` reusable workflows pinned to SHA `144ef855...`.

## Breaking Changes

None.

## Notes for Reviewer

This PR cleans up automated noise by grouping several Dependabot updates into a single atomic change.
