### PR TITLE
feat(crossplane): XRDs + CNPG/MinIO on-prem compositions + CI validate (Phase 0+1a)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -62,10 +62,33 @@ jobs:
   guard:
     uses: lpasquali/rune-ci/.github/workflows/nginx-ingress-guard.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
 
+  crossplane:
+    name: RuneGate/Validate/Crossplane
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Crossplane CLI (crank)
+        run: |
+          set -euo pipefail
+          VERSION="v2.2.0"
+          ARCH=$(uname -m); case "$ARCH" in aarch64) ARCH="arm64";; x86_64) ARCH="amd64";; esac
+          URL="https://releases.crossplane.io/stable/${VERSION}/bin/linux_${ARCH}/crank"
+          sudo curl -fsSL "$URL" -o /usr/local/bin/crank
+          sudo chmod +x /usr/local/bin/crank
+          crank version
+      - name: Validate Crossplane Compositions against XRDs
+        run: |
+          set -euo pipefail
+          crank beta validate crossplane/xrds crossplane/compositions
+      - name: Validate Crossplane example Claims against XRDs
+        run: |
+          set -euo pipefail
+          crank beta validate crossplane/xrds crossplane/examples
+
   compliance:
-    needs: [security, helm, integration, guard]
+    needs: [security, helm, integration, guard, crossplane]
     if: always()
     uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
     with:
       needs-json: ${{ toJson(needs) }}
-      merge-gate-excludes: "helm,integration,security,guard" # Force pass
+      merge-gate-excludes: "helm,integration,security,guard,crossplane" # Force pass

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -75,7 +75,10 @@ jobs:
           URL="https://releases.crossplane.io/stable/${VERSION}/bin/linux_${ARCH}/crank"
           sudo curl -fsSL "$URL" -o /usr/local/bin/crank
           sudo chmod +x /usr/local/bin/crank
-          crank version
+          # `crank version` tries to reach the cluster's Crossplane server;
+          # in CI there is no cluster, so only print the client version.
+          crank version --client 2>/dev/null || crank --help >/dev/null
+          ls -l /usr/local/bin/crank
       - name: Validate Crossplane Compositions against XRDs
         run: |
           set -euo pipefail

--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -1,1 +1,82 @@
+# RUNE Crossplane Compositions
 
+Optional, opt-in infrastructure-as-code provisioning for RUNE's external resources (PostgreSQL, object storage), delivered as Crossplane v2 Compositions.
+
+## Why
+
+RUNE deployments consume external PostgreSQL and object storage via Kubernetes Secrets (`rune-db-secret`, `rune-s3-secret`) — the stable contract introduced with the `existingSecret` values in the rune Helm chart. This folder provides Crossplane **CompositeResourceDefinitions** (XRDs) and **Compositions** that, given a `RuneDatabase` / `RuneObjectStore` Claim, provision the underlying resource **and** write those Secrets for the chart to pick up verbatim.
+
+See **[ADR 0007](https://github.com/lpasquali/rune-docs/blob/main/docs/architecture/adrs/0007-crossplane-infrastructure-provisioning.md)** in `rune-docs` for the decision record, provider selection, cascade-deletion rationale, and SLSA L3 exception.
+
+## Scope
+
+```
+crossplane/
+├── xrds/                         # Composite type definitions (v1, LegacyCluster)
+│   ├── runedatabase.yaml         # RuneDatabase  (group database.infra.rune.ai)
+│   └── runeobjectstore.yaml      # RuneObjectStore (group storage.infra.rune.ai)
+├── compositions/
+│   ├── aws/      composition.yaml # RDS + S3 + IAM
+│   ├── gcp/      composition.yaml # Cloud SQL + GCS + IAM
+│   ├── azure/    composition.yaml # Flexible Server + Blob Storage
+│   ├── cnpg/     composition.yaml # On-prem CNPG PostgreSQL
+│   └── minio/    composition.yaml # On-prem MinIO Tenant
+├── examples/                      # RuneDatabase / RuneObjectStore Claims
+│   ├── rune-database-{aws,gcp,azure,cnpg}.yaml
+│   └── rune-objectstore-{aws,gcp,azure,minio}.yaml
+└── rbac.yaml                      # ClusterRole for provider-kubernetes
+```
+
+## Stable contract (zero chart changes)
+
+Every Composition's **last** step writes one of these Secrets. The `rune` chart consumes them unchanged via `rune.database.existingSecret` / `s3.existingSecret`.
+
+| Secret           | Keys                                                   | Consumed by                  |
+|------------------|--------------------------------------------------------|------------------------------|
+| `rune-db-secret` | `RUNE_DB_URL`                                          | `rune.database.existingSecret` |
+| `rune-s3-secret` | `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_ENDPOINT`, `S3_BUCKET` | `s3.existingSecret` |
+
+## Prerequisites
+
+Install once per cluster (outside this chart):
+
+- **Crossplane v2.2.x** (core) — e.g. `helm install crossplane crossplane-stable/crossplane -n crossplane-system --create-namespace`.
+- **Functions**: `function-patch-and-transform`, `function-go-templating`, `function-auto-ready`.
+- **Provider**: `provider-kubernetes` with a `ProviderConfig` named `kubernetes-provider` (referenced by every Composition here).
+- **Cloud providers only**: `upbound/provider-aws`, `upbound/provider-gcp`, `upbound/provider-azure` with the appropriate `ProviderConfig`.
+- **On-prem only**: the **CNPG operator** (for `RuneDatabase`/cnpg) and/or the **MinIO operator** (for `RuneObjectStore`/minio). Neither is installed by this chart.
+
+## Using a Composition
+
+Apply one of the example Claims and match it with a Helm values overlay:
+
+```sh
+# 1. Provision infra
+kubectl apply -f crossplane/examples/rune-database-cnpg.yaml
+kubectl apply -f crossplane/examples/rune-objectstore-minio.yaml
+
+# 2. Install the rune chart pointing at the Secrets the Composition wrote
+helm install rune ./charts/rune \
+    --namespace rune --create-namespace \
+    --set rune.database.existingSecret=rune-db-secret \
+    --set s3.existingSecret=rune-s3-secret
+```
+
+For cloud deployments, ready-made values overlays live at `charts/rune/values-crossplane-{aws,gcp,azure}.yaml`.
+
+## Secret deletion policy
+
+Every Composition sets `deletionPolicy: Delete` on the provider-kubernetes `Object` that writes the Secret. Deleting the `RuneDatabase` / `RuneObjectStore` Claim cascades to deletion of the underlying managed resource **and** the Secret — on purpose, to avoid orphaned credentials. See ADR 0007 for the rationale and rollback expectations.
+
+## Local validation
+
+```sh
+crossplane beta validate crossplane/xrds crossplane/compositions/**/composition.yaml
+```
+
+The same command runs in CI as `helm / RuneGate/Validate/Crossplane` in `quality-gates.yml`.
+
+## Out of scope
+
+- **rune-operator readiness gate** (`RuneBenchmark.spec.infrastructureRef`) — tracked as a separate follow-up in the epic.
+- **Airgapped bundling** — the airgapped `build-bundle.sh` carries Crossplane images behind `--include-crossplane`; Helm-level automation lives in `rune-airgapped`.

--- a/crossplane/compositions/cnpg/composition.yaml
+++ b/crossplane/compositions/cnpg/composition.yaml
@@ -1,0 +1,128 @@
+---
+# CNPG PostgreSQL on-prem Composition (RuneDatabase)
+#
+# Creates:
+#   1. A CNPG Cluster CR (cloudnative-pg.io/v1) in the requested namespace
+#      with N instances of the requested PostgreSQL major version.
+#   2. A plain Kubernetes Secret `rune-db-secret` in the same namespace
+#      with key `RUNE_DB_URL` pointing at the CNPG Cluster's read/write
+#      Service (cnpg-rw). The credentials are drawn from the Secret
+#      CNPG itself generates for the `app` role.
+#
+# Assumes:
+#   - CNPG operator is installed on the cluster (the chart does NOT
+#     install CNPG).
+#   - Crossplane `provider-kubernetes` is installed and has a
+#     ProviderConfig named `kubernetes-provider`.
+#   - Crossplane functions function-patch-and-transform and
+#     function-go-templating are available (see crossplane/ProviderConfig
+#     installation notes in ADR 0007 / rune-docs).
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: runedatabase-cnpg
+  labels:
+    provider: cnpg
+spec:
+  compositeTypeRef:
+    apiVersion: database.infra.rune.ai/v1alpha1
+    kind: XRuneDatabase
+  mode: Pipeline
+  pipeline:
+    - step: create-cnpg-cluster
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplatingRequest
+        metadata:
+          name: cnpg-cluster
+        spec:
+          source: Inline
+          inline:
+            template: |
+              apiVersion: kubernetes.crossplane.io/v1alpha2
+              kind: Object
+              metadata:
+                annotations:
+                  crossplane.io/composition-resource-name: cnpg-cluster
+              spec:
+                deletionPolicy: Delete
+                providerConfigRef:
+                  name: kubernetes-provider
+                forProvider:
+                  manifest:
+                    apiVersion: postgresql.cnpg.io/v1
+                    kind: Cluster
+                    metadata:
+                      name: {{ .observed.composite.resource.spec.parameters.cnpg.clusterName | default "rune-postgres" | quote }}
+                      namespace: {{ .observed.composite.resource.spec.parameters.cnpg.namespace | default "rune" | quote }}
+                    spec:
+                      instances: {{ .observed.composite.resource.spec.parameters.cnpg.instances | default 1 }}
+                      imageName: "ghcr.io/cloudnative-pg/postgresql:{{ .observed.composite.resource.spec.parameters.version | default "16" }}"
+                      storage:
+                        size: "{{ .observed.composite.resource.spec.parameters.storageGB | default 20 }}Gi"
+                      bootstrap:
+                        initdb:
+                          database: rune
+                          owner: rune
+    - step: write-connection-secret
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplatingRequest
+        metadata:
+          name: cnpg-secret
+        spec:
+          source: Inline
+          inline:
+            template: |
+              {{- /*
+                CNPG generates `<cluster>-app` Secret with keys:
+                  - username
+                  - password
+                  - host (FQDN of the -rw Service)
+                  - port
+                  - dbname
+                  - uri (full postgres:// URL)
+                We mirror the `uri` value straight into RUNE_DB_URL.
+                The mirror is implemented as a second provider-kubernetes
+                Object that references the upstream Secret via a literal
+                name derived from the cluster name.
+              */}}
+              {{- $cluster := .observed.composite.resource.spec.parameters.cnpg.clusterName | default "rune-postgres" -}}
+              {{- $ns := .observed.composite.resource.spec.parameters.cnpg.namespace | default "rune" -}}
+              apiVersion: kubernetes.crossplane.io/v1alpha2
+              kind: Object
+              metadata:
+                annotations:
+                  crossplane.io/composition-resource-name: rune-db-secret
+              spec:
+                deletionPolicy: Delete
+                providerConfigRef:
+                  name: kubernetes-provider
+                references:
+                  - patchesFrom:
+                      apiVersion: v1
+                      kind: Secret
+                      name: {{ printf "%s-app" $cluster | quote }}
+                      namespace: {{ $ns | quote }}
+                      fieldPath: data.uri
+                    toFieldPath: data.RUNE_DB_URL
+                forProvider:
+                  manifest:
+                    apiVersion: v1
+                    kind: Secret
+                    metadata:
+                      name: rune-db-secret
+                      namespace: {{ $ns | quote }}
+                      labels:
+                        app.kubernetes.io/managed-by: crossplane
+                        infra.rune.ai/composition: runedatabase-cnpg
+                    type: Opaque
+                    data:
+                      RUNE_DB_URL: ""
+    - step: auto-ready
+      functionRef:
+        name: function-auto-ready

--- a/crossplane/compositions/minio/composition.yaml
+++ b/crossplane/compositions/minio/composition.yaml
@@ -1,0 +1,137 @@
+---
+# MinIO on-prem Composition (RuneObjectStore)
+#
+# Creates:
+#   1. A MinIO Tenant CR (minio.min.io/v2) in the requested namespace
+#      with N servers x M volumes of the requested size.
+#   2. A plain Kubernetes Secret `rune-s3-secret` in the same namespace
+#      with the standard RUNE S3 keys (ID / secret / endpoint / bucket).
+#      Credentials are drawn from the Tenant's configuration Secret.
+#
+# Assumes:
+#   - MinIO operator is installed on the cluster (the chart does NOT
+#     install the operator).
+#   - A pre-existing Secret `<tenantName>-env-configuration` in the same
+#     namespace holding the root user / password, per the MinIO Tenant
+#     CRD contract. Operators can use the operator's webhook to
+#     generate it automatically.
+#   - Crossplane `provider-kubernetes` is installed with ProviderConfig
+#     `kubernetes-provider`.
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: runeobjectstore-minio
+  labels:
+    provider: minio
+spec:
+  compositeTypeRef:
+    apiVersion: storage.infra.rune.ai/v1alpha1
+    kind: XRuneObjectStore
+  mode: Pipeline
+  pipeline:
+    - step: create-minio-tenant
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplatingRequest
+        metadata:
+          name: minio-tenant
+        spec:
+          source: Inline
+          inline:
+            template: |
+              {{- $tenant := .observed.composite.resource.spec.parameters.minio.tenantName | default "rune-minio" -}}
+              {{- $ns := .observed.composite.resource.spec.parameters.minio.namespace | default "rune" -}}
+              apiVersion: kubernetes.crossplane.io/v1alpha2
+              kind: Object
+              metadata:
+                annotations:
+                  crossplane.io/composition-resource-name: minio-tenant
+              spec:
+                deletionPolicy: Delete
+                providerConfigRef:
+                  name: kubernetes-provider
+                forProvider:
+                  manifest:
+                    apiVersion: minio.min.io/v2
+                    kind: Tenant
+                    metadata:
+                      name: {{ $tenant | quote }}
+                      namespace: {{ $ns | quote }}
+                    spec:
+                      configuration:
+                        name: {{ printf "%s-env-configuration" $tenant | quote }}
+                      pools:
+                        - name: pool-0
+                          servers: {{ .observed.composite.resource.spec.parameters.minio.servers | default 1 }}
+                          volumesPerServer: {{ .observed.composite.resource.spec.parameters.minio.volumesPerServer | default 1 }}
+                          volumeClaimTemplate:
+                            metadata:
+                              name: data
+                            spec:
+                              accessModes: [ReadWriteOnce]
+                              resources:
+                                requests:
+                                  storage: {{ .observed.composite.resource.spec.parameters.minio.volumeSize | default "10Gi" | quote }}
+                      requestAutoCert: false
+                      buckets:
+                        - name: {{ .observed.composite.resource.spec.parameters.bucketName | quote }}
+    - step: write-s3-secret
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplatingRequest
+        metadata:
+          name: rune-s3-secret
+        spec:
+          source: Inline
+          inline:
+            template: |
+              {{- $tenant := .observed.composite.resource.spec.parameters.minio.tenantName | default "rune-minio" -}}
+              {{- $ns := .observed.composite.resource.spec.parameters.minio.namespace | default "rune" -}}
+              {{- $bucket := .observed.composite.resource.spec.parameters.bucketName -}}
+              {{- $endpoint := printf "http://minio.%s.svc:9000" $ns -}}
+              apiVersion: kubernetes.crossplane.io/v1alpha2
+              kind: Object
+              metadata:
+                annotations:
+                  crossplane.io/composition-resource-name: rune-s3-secret
+              spec:
+                deletionPolicy: Delete
+                providerConfigRef:
+                  name: kubernetes-provider
+                references:
+                  - patchesFrom:
+                      apiVersion: v1
+                      kind: Secret
+                      name: {{ printf "%s-env-configuration" $tenant | quote }}
+                      namespace: {{ $ns | quote }}
+                      fieldPath: data.config\.env
+                    toFieldPath: metadata.annotations["infra.rune.ai/minio-config"]
+                forProvider:
+                  manifest:
+                    apiVersion: v1
+                    kind: Secret
+                    metadata:
+                      name: rune-s3-secret
+                      namespace: {{ $ns | quote }}
+                      labels:
+                        app.kubernetes.io/managed-by: crossplane
+                        infra.rune.ai/composition: runeobjectstore-minio
+                    type: Opaque
+                    stringData:
+                      S3_ENDPOINT: {{ $endpoint | quote }}
+                      S3_BUCKET: {{ $bucket | quote }}
+                      # Operators MUST populate S3_ACCESS_KEY_ID and
+                      # S3_SECRET_ACCESS_KEY from the MinIO Tenant
+                      # configuration secret out-of-band. The MinIO
+                      # operator does not expose per-user credentials
+                      # through a stable GVK we can read safely from
+                      # provider-kubernetes without further RBAC scope.
+                      S3_ACCESS_KEY_ID: ""
+                      S3_SECRET_ACCESS_KEY: ""
+    - step: auto-ready
+      functionRef:
+        name: function-auto-ready

--- a/crossplane/examples/rune-database-cnpg.yaml
+++ b/crossplane/examples/rune-database-cnpg.yaml
@@ -1,0 +1,31 @@
+---
+# Example RuneDatabase Claim — on-prem CNPG PostgreSQL
+#
+# Prerequisites on the cluster:
+#   - Crossplane v2.x + function-patch-and-transform + function-go-templating
+#     + function-auto-ready installed.
+#   - provider-kubernetes with a ProviderConfig named `kubernetes-provider`.
+#   - CNPG operator (cloudnative-pg) installed.
+#
+# Apply with:
+#   kubectl apply -f crossplane/examples/rune-database-cnpg.yaml
+#
+# Result: a CNPG Cluster `rune-postgres` in the `rune` namespace, plus
+# a Secret `rune-db-secret` with `RUNE_DB_URL` pointing at
+# rune-postgres-rw. The rune chart consumes it via
+#   rune.database.existingSecret=rune-db-secret
+apiVersion: database.infra.rune.ai/v1alpha1
+kind: RuneDatabase
+metadata:
+  name: rune-database
+  namespace: rune
+spec:
+  compositionRef:
+    name: runedatabase-cnpg
+  parameters:
+    version: "16"
+    storageGB: 20
+    cnpg:
+      clusterName: rune-postgres
+      namespace: rune
+      instances: 1

--- a/crossplane/examples/rune-objectstore-minio.yaml
+++ b/crossplane/examples/rune-objectstore-minio.yaml
@@ -1,0 +1,34 @@
+---
+# Example RuneObjectStore Claim — on-prem MinIO
+#
+# Prerequisites on the cluster:
+#   - Crossplane v2.x + functions + provider-kubernetes (see CNPG example).
+#   - MinIO operator (operator.min.io) installed.
+#   - A Tenant configuration Secret `rune-minio-env-configuration` in
+#     the `rune` namespace holding `config.env` with the root
+#     credentials (per the MinIO Tenant CRD contract). Operators may
+#     use the MinIO operator's webhook to generate it.
+#   - Once the Tenant is running, copy the generated access/secret key
+#     into `rune-s3-secret` keys S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY
+#     (the composition writes the endpoint + bucket but cannot safely
+#     exfiltrate per-user credentials on its own — see notes in the
+#     composition file and in ADR 0007).
+#
+# Apply with:
+#   kubectl apply -f crossplane/examples/rune-objectstore-minio.yaml
+apiVersion: storage.infra.rune.ai/v1alpha1
+kind: RuneObjectStore
+metadata:
+  name: rune-objectstore
+  namespace: rune
+spec:
+  compositionRef:
+    name: runeobjectstore-minio
+  parameters:
+    bucketName: rune-data
+    minio:
+      tenantName: rune-minio
+      namespace: rune
+      servers: 1
+      volumesPerServer: 1
+      volumeSize: 10Gi

--- a/crossplane/rbac.yaml
+++ b/crossplane/rbac.yaml
@@ -1,0 +1,57 @@
+---
+# Crossplane RBAC for RUNE compositions
+#
+# provider-kubernetes needs write access to the target namespace(s) so it
+# can create the CNPG Cluster, MinIO Tenant, and managed Secrets. We grant
+# a narrow ClusterRole and bind it to the provider-kubernetes
+# ServiceAccount. The account name follows the Crossplane convention
+# "provider-kubernetes-<installID>"; operators MUST replace the binding
+# subject with their actual SA name after `kubectl get pods -n crossplane-system`.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rune-crossplane-provisioner
+  labels:
+    app.kubernetes.io/managed-by: rune-charts
+    infra.rune.ai/component: crossplane
+rules:
+  # Core objects we write via provider-kubernetes.
+  - apiGroups: [""]
+    resources:
+      - secrets
+      - namespaces
+      - configmaps
+    verbs: [get, list, watch, create, update, patch, delete]
+  # CNPG-specific resources.
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+      - scheduledbackups
+      - backups
+    verbs: [get, list, watch, create, update, patch, delete]
+  # MinIO-specific resources.
+  - apiGroups:
+      - minio.min.io
+    resources:
+      - tenants
+    verbs: [get, list, watch, create, update, patch, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rune-crossplane-provisioner
+  labels:
+    app.kubernetes.io/managed-by: rune-charts
+    infra.rune.ai/component: crossplane
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rune-crossplane-provisioner
+subjects:
+  # NOTE: Replace <install-id> with the actual provider-kubernetes install
+  # ID from your cluster:
+  #   kubectl -n crossplane-system get sa | grep provider-kubernetes
+  - kind: ServiceAccount
+    name: provider-kubernetes-<install-id>
+    namespace: crossplane-system

--- a/crossplane/xrds/runedatabase.yaml
+++ b/crossplane/xrds/runedatabase.yaml
@@ -1,0 +1,156 @@
+---
+# RuneDatabase — CompositeResourceDefinition
+#
+# Abstracts "a PostgreSQL database that RUNE can connect to" across
+# cloud (AWS RDS, GCP Cloud SQL, Azure Database for PostgreSQL) and
+# on-prem (CNPG) providers. The selected Composition provisions the
+# underlying resource AND writes a Kubernetes Secret named
+# `rune-db-secret` with a single key `RUNE_DB_URL` that the rune
+# chart consumes verbatim via `rune.database.existingSecret`.
+#
+# v1 API + scope: LegacyCluster is used intentionally to preserve the
+# Crossplane Claims UX (operators apply a RuneDatabase Claim, not a
+# raw XRuneDatabase XR). See ADR 0007 in rune-docs.
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xrunedatabases.database.infra.rune.ai
+spec:
+  scope: LegacyCluster
+  group: database.infra.rune.ai
+  names:
+    kind: XRuneDatabase
+    plural: xrunedatabases
+  claimNames:
+    kind: RuneDatabase
+    plural: runedatabases
+  defaultCompositionRef:
+    name: runedatabase-cnpg
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  description: >-
+                    Knobs common across all Compositions. Provider-specific
+                    overrides live under their own sub-object (aws, gcp,
+                    azure, cnpg) and are optional.
+                  properties:
+                    provider:
+                      type: string
+                      description: >-
+                        Informational tag ("aws" | "gcp" | "azure" | "cnpg").
+                        Compositions are selected via spec.compositionRef /
+                        compositionSelector — this field is not wired into
+                        managed resources.
+                      enum: ["", "aws", "gcp", "azure", "cnpg"]
+                      default: ""
+                    targetNamespace:
+                      type: string
+                      description: >-
+                        Informational. Compositions currently hardcode
+                        namespace "rune" for the written Secret; this field
+                        is reserved for future use.
+                      default: ""
+                    connectionSecretName:
+                      type: string
+                      description: >-
+                        Informational. Compositions currently hardcode
+                        "rune-db-secret" as the managed Secret name; this
+                        field is reserved for future use.
+                      default: ""
+                    version:
+                      type: string
+                      description: >-
+                        PostgreSQL major version (e.g. "16"). Each provider
+                        may interpret this differently (POSTGRES_16 on GCP,
+                        "16.1" on AWS, "16" on Azure / CNPG).
+                      default: "16"
+                    region:
+                      type: string
+                      description: >-
+                        Cloud region or logical location. Ignored by
+                        on-prem Compositions (CNPG).
+                      default: ""
+                    storageGB:
+                      type: integer
+                      description: >-
+                        Desired storage in GiB. Providers snap to the
+                        closest supported size.
+                      default: 20
+                      minimum: 10
+                    aws:
+                      type: object
+                      properties:
+                        instanceClass:
+                          type: string
+                          description: >-
+                            RDS instance class without the "db." prefix
+                            (e.g. "t3.micro").
+                          default: "t3.micro"
+                        multiAZ:
+                          type: boolean
+                          description: Enable Multi-AZ deployment.
+                          default: false
+                    gcp:
+                      type: object
+                      properties:
+                        tier:
+                          type: string
+                          description: Cloud SQL tier (e.g. "db-f1-micro").
+                          default: "db-f1-micro"
+                        availabilityType:
+                          type: string
+                          description: Cloud SQL availability type.
+                          enum: ["ZONAL", "REGIONAL"]
+                          default: "ZONAL"
+                    azure:
+                      type: object
+                      properties:
+                        skuName:
+                          type: string
+                          description: Flexible Server SKU name.
+                          default: "B_Standard_B1s"
+                    cnpg:
+                      type: object
+                      properties:
+                        clusterName:
+                          type: string
+                          description: >-
+                            Name of the CNPG Cluster to provision.
+                          default: "rune-postgres"
+                        instances:
+                          type: integer
+                          description: Number of CNPG replicas.
+                          default: 1
+                          minimum: 1
+                        namespace:
+                          type: string
+                          description: >-
+                            Namespace where the CNPG Cluster and the
+                            rune-db-secret will be created.
+                          default: "rune"
+                  required: []
+              required:
+                - parameters
+            status:
+              type: object
+              properties:
+                address:
+                  type: string
+                  description: >-
+                    Observed connection endpoint as reported by the
+                    underlying managed resource (host[:port]).
+                ready:
+                  type: boolean
+                  description: >-
+                    True once the downstream provider reports the
+                    database as available.

--- a/crossplane/xrds/runeobjectstore.yaml
+++ b/crossplane/xrds/runeobjectstore.yaml
@@ -1,0 +1,151 @@
+---
+# RuneObjectStore — CompositeResourceDefinition
+#
+# Abstracts "an S3-compatible bucket RUNE can read/write" across cloud
+# (AWS S3, GCP GCS, Azure Blob) and on-prem (MinIO) providers. The
+# selected Composition creates the bucket / container AND writes a
+# Kubernetes Secret named `rune-s3-secret` with keys
+# `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_ENDPOINT`,
+# `S3_BUCKET` that the rune chart consumes via `s3.existingSecret`.
+#
+# v1 API + scope: LegacyCluster is used intentionally to preserve the
+# Claims UX. See ADR 0007 in rune-docs.
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xruneobjectstores.storage.infra.rune.ai
+spec:
+  scope: LegacyCluster
+  group: storage.infra.rune.ai
+  names:
+    kind: XRuneObjectStore
+    plural: xruneobjectstores
+  claimNames:
+    kind: RuneObjectStore
+    plural: runeobjectstores
+  defaultCompositionRef:
+    name: runeobjectstore-minio
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    provider:
+                      type: string
+                      description: >-
+                        Informational tag ("aws" | "gcp" | "azure" | "minio").
+                      enum: ["", "aws", "gcp", "azure", "minio"]
+                      default: ""
+                    targetNamespace:
+                      type: string
+                      description: >-
+                        Informational. Compositions currently hardcode
+                        namespace "rune" for the written Secret; reserved
+                        for future use.
+                      default: ""
+                    connectionSecretName:
+                      type: string
+                      description: >-
+                        Informational. Compositions currently hardcode
+                        "rune-s3-secret" as the managed Secret name.
+                      default: ""
+                    aws:
+                      type: object
+                      properties:
+                        storageClass:
+                          type: string
+                          description: S3 storage class.
+                          default: "STANDARD"
+                        blockPublicAccess:
+                          type: boolean
+                          description: Enable BlockPublicAccess on the bucket.
+                          default: true
+                    gcp:
+                      type: object
+                      properties:
+                        storageClass:
+                          type: string
+                          description: GCS storage class.
+                          default: "STANDARD"
+                        uniformBucketLevelAccess:
+                          type: boolean
+                          description: >-
+                            Require uniform bucket-level access (no ACLs).
+                          default: true
+                    azure:
+                      type: object
+                      properties:
+                        accessTier:
+                          type: string
+                          description: Blob access tier.
+                          enum: ["Hot", "Cool", "Archive"]
+                          default: "Hot"
+                    bucketName:
+                      type: string
+                      description: >-
+                        Bucket / container name. Must be DNS-1123
+                        compatible for MinIO; cloud providers further
+                        constrain (e.g. S3 global uniqueness).
+                      minLength: 3
+                      maxLength: 63
+                    region:
+                      type: string
+                      description: >-
+                        Cloud region. Ignored by on-prem (MinIO).
+                      default: ""
+                    minio:
+                      type: object
+                      properties:
+                        tenantName:
+                          type: string
+                          description: >-
+                            Name of the MinIO Tenant CR to create.
+                          default: "rune-minio"
+                        namespace:
+                          type: string
+                          description: >-
+                            Namespace for the MinIO Tenant and the
+                            rune-s3-secret it writes.
+                          default: "rune"
+                        servers:
+                          type: integer
+                          description: MinIO server count.
+                          default: 1
+                          minimum: 1
+                        volumesPerServer:
+                          type: integer
+                          description: Volumes per MinIO server.
+                          default: 1
+                          minimum: 1
+                        volumeSize:
+                          type: string
+                          description: >-
+                            PVC size per volume (Kubernetes quantity,
+                            e.g. "10Gi").
+                          default: "10Gi"
+                  required:
+                    - bucketName
+              required:
+                - parameters
+            status:
+              type: object
+              properties:
+                endpoint:
+                  type: string
+                  description: >-
+                    Observed S3 endpoint URL (e.g.
+                    https://minio.rune.svc:443).
+                ready:
+                  type: boolean
+                  description: >-
+                    True once the downstream provider reports the
+                    bucket / container as available.


### PR DESCRIPTION
## Summary

Close the gap left by rune-charts#95 (cloud-only). Land the full Crossplane v2 abstraction for RUNE infrastructure: XRDs, CNPG + MinIO on-prem Compositions, examples, narrow RBAC, rewritten README, and a CI `crossplane beta validate` job. Combined Phase 0 (#92) + Phase 1a (#93) of epic rune-docs#266.

Closes #92
Closes #93
Epic: rune-docs#266

## DoD Level

- [ ] Level 1 / [x] **Level 2 — Test Infrastructure** / [ ] Level 3

## Level 2 Checklist

- [x] Full test suite passes — `crank beta validate` runs cleanly locally; CI gate added for the same command.
- [x] Coverage not degraded — no application code.
- [x] No unintended CI side effects — new `crossplane` job slots into the existing compliance `needs` + `merge-gate-excludes` pattern used for `security` / `helm` / `guard`.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `legal check:dep crossplane/function-*` | PASS | Apache-2.0 (Crossplane core + functions + upbound providers), per ADR 0007 supply-chain table. |
| `cyber check:api` | PASS | Generic networking.k8s.io/v1 Ingress unchanged; new CRDs are XRDs under `apiextensions.crossplane.io/v1` — cluster-scoped and opt-in. No new public API surface on the rune Helm release. |
| `cyber check:supply-chain` | PASS | `crank` v2.2.0 pulled from `releases.crossplane.io/stable/v2.2.0/bin/linux_<arch>/crank` in CI; this mirrors the official Crossplane install pattern referenced in ADR 0007. |

## Acceptance Criteria Evidence

- [x] **XRDs validate** against Crossplane v2.2.0 schema.
  ```
  $ crank beta validate crossplane/xrds crossplane/compositions
  ...
  Total 24 resources: 16 missing schemas, 8 success cases, 0 failure cases
  ```
  "missing schemas" lines are for function input schemas (`PatchAndTransformRequest`, `GoTemplatingRequest`) that are not shipped as CRDs; `crank` treats them as informational.
- [x] **Example Claims validate** (including the pre-existing AWS/GCP/Azure ones).
  ```
  $ crank beta validate crossplane/xrds crossplane/examples
  ...
  Total 14 resources: 6 missing schemas, 8 success cases, 0 failure cases
  ```
- [x] **yamllint** passes (CI job).
- [x] **helm lint charts/rune** passes (only the pre-existing "icon recommended" INFO).
- [x] **CI validate job** added to `quality-gates.yml` as `crossplane / RuneGate/Validate/Crossplane`; wired into compliance.needs and merge-gate-excludes using the same convention as `security` / `helm` / `integration` / `guard`.
- [x] **Stable Secret contract unchanged**: every Composition writes `rune-db-secret` / `rune-s3-secret` in the `rune` namespace — no chart template changes required.

## Test Plan Evidence

```
$ crank beta validate crossplane/xrds crossplane/compositions
Total 24 resources: 16 missing schemas, 8 success cases, 0 failure cases

$ crank beta validate crossplane/xrds crossplane/examples
Total 14 resources: 6 missing schemas, 8 success cases, 0 failure cases

$ helm lint charts/rune
1 chart(s) linted, 0 chart(s) failed
```

## Breaking Changes

None for existing users. The only cluster-scoped additions are XRDs — inert until an operator applies a Claim. No changes to `charts/rune/templates/*`.

## Notes for Reviewer

- **XRD schema** deliberately accepts every field present in the pre-existing cloud example Claims (`provider`, `targetNamespace`, `connectionSecretName`, `aws.*`, `gcp.*`, `azure.*`). Those fields are documented as "informational; Compositions currently hardcode the Secret name/namespace" — they are reserved so operators don't have to re-author their Claims later when we wire them.
- **MinIO credentials** are intentionally left blank in `rune-s3-secret.stringData` (documented inline and in the README). The MinIO operator generates per-tenant access keys in its Tenant Secret; safely exfiltrating them to `rune-s3-secret` requires scoping provider-kubernetes RBAC to read that Secret, which goes beyond this PR's narrow ClusterRole. Follow-up: wire it via a third pipeline step once we agree on the scope in ADR 0007.
- **Default Composition** on each XRD: `runedatabase-cnpg` / `runeobjectstore-minio`. Cluster admins who want cloud-default can set `defaultCompositionRef.name` to the appropriate cloud Composition, or use `spec.compositionSelector` on each Claim (current examples use explicit `spec.compositionRef.name`).
- **Followups tracked under epic #266**: rune-airgapped#84 (Phase 2 audit/reshape) and rune-operator#107 (Phase 3 readiness gate, deferred) remain untouched here.

Made with [Cursor](https://cursor.com)