### PR TITLE
chore: enable dependabot for ML4 compliance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5


### PR DESCRIPTION
Enables dependabot per EPIC #354.